### PR TITLE
Added the `/login/validate-token` route.

### DIFF
--- a/bitcamp-openapi.yaml
+++ b/bitcamp-openapi.yaml
@@ -82,6 +82,23 @@ paths:
         400:
           description: Invalid login
           content: {}
+  /login/validate-token:
+    get:
+      tags:
+        - login
+      summary: Validate a user's authentication token
+      description: Returns whether the user's auth token is valid
+      operationId: validateToken
+      security:
+        - HackerToken: []
+        - AdminToken: []
+      responses:
+        200:
+          description: The user has a valid token
+          content: {}
+        400:
+          description: Invalid token
+          content: {}
   /announce:
     get:
       tags:


### PR DESCRIPTION
Closes #15.

I chose to have the `/login/validate-token` route indicate the validity of the user's token based on the response code (`200` for valid token, `400` for invalid token).

Would it be better to just return an object with the shape `{ isValid: bool }`?